### PR TITLE
Fix(Issue-19): User can select previous date or time

### DIFF
--- a/source/contexts/ReminderContext/types.ts
+++ b/source/contexts/ReminderContext/types.ts
@@ -2,8 +2,9 @@ import { iconNames } from '../../utils/IconMap';
 
 export type Reminder = {
   title: string;
-  date: string | 'daily';
   time: string;
+  date: string | 'daily';
+  year: string;
   icon: iconNames;
   id: number;
 };

--- a/source/screens/AddReminderScreen/AddReminderScreen.tsx
+++ b/source/screens/AddReminderScreen/AddReminderScreen.tsx
@@ -11,7 +11,7 @@ import {
 import { AddReminderScreenProps } from './types';
 import { useReminderForm } from './hooks/useReminderForm';
 import DateTimePicker from 'react-native-modal-datetime-picker';
-import { getMonth } from '../ProfilePage/hooks/utils';
+import { getMonth, getMonthIndex } from '../ProfilePage/hooks/utils';
 import styles from './styles';
 import BackArrow from '../../assets/back_arrow.png';
 import CheckBox from '@react-native-community/checkbox';
@@ -31,7 +31,7 @@ const AddReminderScreen = ({ navigation }: AddReminderScreenProps) => {
 
   const onSave = () => {
     const values = form.state.values;
-    const { title, date, time, icon } = values;
+    const { title, date, time, year, icon } = values;
     let missingFields = '';
 
     if (title === '') missingFields += 'title ';
@@ -48,6 +48,105 @@ const AddReminderScreen = ({ navigation }: AddReminderScreenProps) => {
       setSheetMessage(finalMessage);
       setShowSheet(true);
       return;
+    }
+
+    if (date !== 'Daily') {
+      const currentTime = new Date();
+
+      // Check whether the selected year has already passed
+      if (year < String(currentTime.getFullYear())) {
+        setSheetTitle('Invalid Date');
+        setSheetMessage('The year selected has already passed.');
+        setShowSheet(true);
+        return;
+      }
+
+      // Check whether the selected month and date have already passed
+      const [monthStr, dayStr] = date.split(' ');
+      if (getMonthIndex(monthStr) < currentTime.getMonth()) {
+        setSheetTitle('Invalid Date');
+        setSheetMessage('The month selected has already passed.');
+        setShowSheet(true);
+        return;
+      } else if (Number(dayStr) < currentTime.getDate()) {
+        setSheetTitle('Invalid Date');
+        setSheetMessage('The date selected has already passed.');
+        setShowSheet(true);
+        return;
+      }
+
+      const [selectedTime, extra] = time.replace(/\s+/g, ' ').split(' ');
+      const [selectedHoursStr, selectedMinutesStr] = selectedTime.split(':');
+      const currentHours = currentTime.getHours();
+      const currentMinutes = currentTime.getMinutes();
+
+      // Check whether the selected time has already passed for today specifically
+      if (
+        year === String(currentTime.getFullYear()) &&
+        getMonthIndex(monthStr) === currentTime.getMonth() &&
+        Number(dayStr) === currentTime.getDate()
+      ) {
+        // If current time is in PM
+        if (currentHours > 12) {
+          console.log('>>> Extra', extra);
+          // Selecting AM will always be invalid
+          if (extra === 'AM') {
+            setSheetTitle('Invalid Time');
+            setSheetMessage('The time selected has already passed.');
+            setShowSheet(true);
+            return;
+          }
+
+          // Selecting PM, need to check hours and minutes are passed
+          const selectedHours = Number(selectedHoursStr) + 12;
+          if (
+            selectedHours < currentHours ||
+            (selectedHours === currentHours &&
+              Number(selectedMinutesStr) < currentMinutes)
+          ) {
+            setSheetTitle('Invalid Time');
+            setSheetMessage('The time selected has already passed.');
+            setShowSheet(true);
+            return;
+          }
+        }
+        // If current time is in 12 AM/PM
+        else if (Number(selectedHoursStr) === 12) {
+          // Selecting 12 AM is always invalid
+          if (extra === 'AM') {
+            setSheetTitle('Invalid Time');
+            setSheetMessage('The time selected has already passed.');
+            setShowSheet(true);
+            return;
+          }
+
+          // After 12 PM, can not set reminder for 12 PM
+          if (currentHours >= 12) {
+            setSheetTitle('Invalid Time');
+            setSheetMessage('The time selected has already passed.');
+            setShowSheet(true);
+            return;
+          }
+        }
+        // If current time is in AM
+        else {
+          // Selecting PM is always valid
+          // Selecting AM, need to check hours and minutes are passed
+          if (extra !== 'PM') {
+            const selectedHours = Number(selectedHoursStr);
+            if (
+              selectedHours < currentHours ||
+              (selectedHours === currentHours &&
+                Number(selectedMinutesStr) < currentMinutes)
+            ) {
+              setSheetTitle('Invalid Time');
+              setSheetMessage('The time selected has already passed.');
+              setShowSheet(true);
+              return;
+            }
+          }
+        }
+      }
     }
 
     form.handleSubmit();
@@ -173,8 +272,13 @@ const AddReminderScreen = ({ navigation }: AddReminderScreenProps) => {
                           }),
                         ) - 1,
                       );
+                      const year = t.toLocaleDateString('en-US', {
+                        year: 'numeric',
+                      });
+
                       const selectedDate = `${month} ${date}`;
                       field.handleChange(selectedDate);
+                      form.setFieldValue('year', year);
                       setShowDatePicker(false);
                       setIsDaily(false);
                     }}

--- a/source/screens/AddReminderScreen/hooks/types.ts
+++ b/source/screens/AddReminderScreen/hooks/types.ts
@@ -5,4 +5,5 @@ export type ReminderFormType = {
   icon: iconNames;
   time: string;
   date: string;
+  year: string;
 };

--- a/source/screens/AddReminderScreen/hooks/useReminderForm.ts
+++ b/source/screens/AddReminderScreen/hooks/useReminderForm.ts
@@ -9,6 +9,7 @@ const defaultValues: ReminderFormType = {
   icon: iconNames.placeholder,
   time: '',
   date: '',
+  year: '',
 };
 
 export const useReminderForm = () => {
@@ -22,6 +23,7 @@ export const useReminderForm = () => {
       date: value.date,
       time: value.time,
       icon: value.icon,
+      year: value.year,
     };
 
     addReminder(newReminder);

--- a/source/screens/ProfilePage/hooks/utils.ts
+++ b/source/screens/ProfilePage/hooks/utils.ts
@@ -61,3 +61,21 @@ export const getMonth = (month: number) => {
 
   return months[month];
 };
+
+export const getMonthIndex = (month: string) => {
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  return months.indexOf(month);
+};

--- a/source/screens/UpdateReminderScreen/hooks/useGetUpdateReminderForm.ts
+++ b/source/screens/UpdateReminderScreen/hooks/useGetUpdateReminderForm.ts
@@ -13,6 +13,7 @@ const useGetUpdateReminderForm = (currentReminder: Reminder) => {
       date: value.date,
       time: value.time,
       icon: value.icon,
+      year: value.year,
     };
 
     updateReminder(newReminder);


### PR DESCRIPTION
Issue: #19
- User is able to select past years, months, days and times when creating or updating reminders.

Changes:
- Disallow selecting past years, months, days and times when creating or updating reminders.
- Move/adjust validation into form hooks so both add and update flows use the same checks: useReminderForm, useGetUpdateReminderForm.
- Use canonical month index lookup to compare dates: getMonthIndex.
- Surface validation errors to users via BottomSheet on the Add/Update screens.